### PR TITLE
ci: update workflow to publish to pypi

### DIFF
--- a/.github/workflows/tag_and_publish.yml
+++ b/.github/workflows/tag_and_publish.yml
@@ -62,13 +62,12 @@ jobs:
         add: '["README.md"]'
   tag:
     needs: update_badges
-    if: ${{github.event.repository.name == 'aind-library-template'}}
     uses: AllenNeuralDynamics/aind-github-actions/.github/workflows/tag.yml@main
     secrets:
       SERVICE_TOKEN: ${{ secrets.SERVICE_TOKEN }}
   publish:
     needs: tag
-    if: false
+    if: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR attempts to update the tag and publish workflow to enable semantic versioning and publishing to pypi. I think we are in a good place to release!

`svc-aindscicomp` needs to be added as an admin to this repo if it has not been already.