### PR TITLE
fix: (pre-data club) analysis version, job skipping in dispatcher, missing result error (#48, #30, #745, #18)

### DIFF
--- a/src/analysis_pipeline_utils/metadata.py
+++ b/src/analysis_pipeline_utils/metadata.py
@@ -248,15 +248,22 @@ def get_codeocean_process_metadata(
 
     capsule = client.capsules.get_capsule(capsule_id)
     process.name = capsule.name
-    if not version:
-        branch = os.getenv("CO_CAPSULE_BRANCH", "HEAD")
+    branch = os.getenv("CO_CAPSULE_BRANCH", "HEAD")
+    if version:
+        # Code Ocean reports the release of a pinned pipeline component as an
+        # int holding the major version only; expand it to '<major>.<minor>'
+        # so it matches the version recorded for an unpinned run.
+        version = get_release_version_for_major(capsule, version)
+    else:
         patch_list = os.getenv("PATCH_COMMITS")
         version = get_capsule_version_ignoring_patches(
             capsule, patch_list=patch_list, branch=branch
         )
-        hash = get_capsule_commit_hash(capsule, branch)
-        version = version or hash
-        process.notes = f"Git commit hash: {hash}"
+    # Recorded outside code so it never affects job-skipping, but stays
+    # available for debugging which commit actually ran.
+    hash = get_capsule_commit_hash(capsule, branch)
+    version = version or hash
+    process.notes = f"Git commit hash: {hash}"
 
     if computation.data_assets:
         input_data = [
@@ -361,6 +368,59 @@ def get_capsule_commit_hash(capsule: Capsule, branch="HEAD") -> str:
     return git_commit_hash.split()[0]  # Return the commit hash part
 
 
+def get_capsule_releases(capsule: Capsule) -> List[dict]:
+    """Get all releases for a specific capsule, oldest first.
+
+    Args:
+        capsule: Capsule object
+
+    Returns:
+        List of release dicts, empty if the capsule has no release capsule
+    """
+    if not capsule.release_capsule:
+        return []
+    client = _initialize_codeocean_client()
+    release_capsule = client.capsules.get_capsule(capsule.release_capsule)
+    return release_capsule.versions or []
+
+
+def format_release_version(release: dict) -> str:
+    """Format a Code Ocean release as a '<major>.<minor>' version string.
+
+    Args:
+        release: Release dict from the Code Ocean API
+
+    Returns:
+        str: Version string, e.g. '2.0'
+    """
+    return f"{release['major_version']}.{release['minor_version']}"
+
+
+def get_release_version_for_major(capsule: Capsule, major_version: int) -> str:
+    """Resolve a major version number to a full '<major>.<minor>' string.
+
+    Code Ocean reports the release of a pinned pipeline component as an int
+    holding only the major version. Look up the matching release so the
+    recorded version has the same form as for an unpinned run.
+
+    Args:
+        capsule: Capsule object
+        major_version: Major version reported by the pipeline process
+
+    Returns:
+        str: Version string, falling back to the major version alone
+        if no matching release is found
+    """
+    matching = [
+        release
+        for release in get_capsule_releases(capsule)
+        if release["major_version"] == major_version
+    ]
+    if not matching:
+        return str(major_version)
+    return format_release_version(matching[-1])
+
+
 def get_latest_release(capsule: Capsule) -> Optional[dict]:
     """Get the latest release information for a specific capsule.
     Args:
@@ -368,11 +428,9 @@ def get_latest_release(capsule: Capsule) -> Optional[dict]:
     Returns:
         dict: Latest release information, or None if no releases found
     """
-    if not capsule.release_capsule:
+    versions = get_capsule_releases(capsule)
+    if not versions:
         return None
-    client = _initialize_codeocean_client()
-    release_capsule = client.capsules.get_capsule(capsule.release_capsule)
-    versions = release_capsule.versions
     latest = versions[-1]
     return latest
 
@@ -444,33 +502,56 @@ def get_commits_since_release(
 def get_capsule_version_ignoring_patches(
     capsule: Capsule, branch="HEAD", patch_list: Optional[str] = None
 ) -> Optional[str]:
-    """Get the capsule version from the latest release, ignoring patch commits.
+    """Get the capsule version from the latest release.
+
+    The latest release is used whenever the capsule has one, so that commits
+    made after it do not change the recorded version. This lets the analysis
+    owner decide what counts as a substantial new version of the analysis by
+    cutting a new release, rather than having every commit start a new one.
+
+    Commits since the release do not change the version, but are reported as
+    a warning unless they are listed in patch_list.
+
     Args:
         capsule: Capsule object
         branch: Branch name or 'HEAD' to specify which version to retrieve
-        patch_list: Optional comma-separated list of patch commit hashes to ignore
+        patch_list: Optional comma-separated list of patch commit hashes to
+            ignore when deciding whether to warn
+
     Returns:
         str: Version of the capsule based on the latest release, or None
-        if there are non-patch commits since release
+        if the capsule has no releases
     """
+    release = get_latest_release(capsule)
+    if release is None:
+        return None
+    version = format_release_version(release)
+
     patch_list = patch_list.split(",") if patch_list else []
     try:
-        release = get_latest_release(capsule)
-        if release is not None:
-            commits = get_commits_since_release(
-                capsule, release_time=release["release_time"], branch=branch
-            )
-            if not set(commits).difference(set(patch_list)):
-                return f"{release['major_version']}.{release['minor_version']}"
+        commits = get_commits_since_release(
+            capsule, release_time=release["release_time"], branch=branch
+        )
     except Exception:
-        # Version lookup is best-effort metadata; callers fall back to the
-        # commit hash. Never fail an analysis run over it.
+        # Only the warning below depends on this; the version does not, so a
+        # failure here must never change the recorded version.
         logging.warning(
-            f"Could not resolve release version for capsule {capsule.id}, "
-            "falling back to commit hash.",
+            f"Could not list commits since release {version} "
+            f"for capsule {capsule.name}.",
             exc_info=True,
         )
-    return None
+        return version
+
+    unpatched = set(commits).difference(set(patch_list))
+    if unpatched:
+        logging.warning(
+            f"Capsule {capsule.name} has {len(unpatched)} commit(s) since "
+            f"release {version}, which is still being recorded as the "
+            "analysis version. Cut a new release if those commits "
+            "substantially change results, otherwise jobs already processed "
+            "under this version will not be re-run."
+        )
+    return version
 
 
 def get_capsule_url(capsule: Capsule) -> str:

--- a/src/analysis_pipeline_utils/metadata.py
+++ b/src/analysis_pipeline_utils/metadata.py
@@ -1,5 +1,6 @@
 """Utility functions for handling metadata related operations"""
 
+import copy
 import logging
 import os
 import subprocess
@@ -88,6 +89,7 @@ def update_analysis_process(
        combining Code Ocean metadata with analysis job data.
 
     Args:
+        process: Base process record to build on. Left unmodified.
         dispatch_inputs: AnalysisDispatchModel containing analysis metadata including:
             - s3_location (str): S3 URL for input data
         **params: Additional parameters passed to the process
@@ -95,6 +97,13 @@ def update_analysis_process(
     Returns:
         ps.DataProcess: analysis process record with combined metadata
     """
+
+    # Callers fetch one base record per capsule and reuse it for every job, so
+    # the updates below have to land on a copy. Applied in place they would
+    # accumulate: input_data grows job by job and parameters carry over from
+    # the previous job. Both feed processing_prefix(), so the record hash used
+    # to detect already-processed jobs would drift after the first job.
+    process = copy.deepcopy(process)
 
     # add s3_location and parameters from analysis_job_dict
     new_inputs = [DataAsset(url=url) for url in dispatch_inputs.s3_location]

--- a/src/analysis_pipeline_utils/metadata.py
+++ b/src/analysis_pipeline_utils/metadata.py
@@ -4,7 +4,7 @@ import logging
 import os
 import subprocess
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import aind_data_schema.core.processing as ps
 from aind_data_access_api.document_db import MetadataDbClient
@@ -368,14 +368,32 @@ def get_latest_release(capsule: Capsule) -> Optional[dict]:
     return latest
 
 
+def _as_git_date(release_time: Union[int, str]) -> str:
+    """Normalize a Code Ocean release time to a date git can parse.
+
+    The Code Ocean API returns release_time as a unix timestamp (int), while
+    callers may also pass an already-formatted string.
+
+    Args:
+        release_time: Unix timestamp or date string
+
+    Returns:
+        str: ISO 8601 timestamp
+    """
+    if isinstance(release_time, str):
+        return release_time
+    return datetime.fromtimestamp(release_time).isoformat()
+
+
 def get_commits_since_release(
-    capsule: Capsule, release_time: str, branch="HEAD"
+    capsule: Capsule, release_time: Union[int, str], branch="HEAD"
 ) -> List[str]:
     """Get commits since the release time from the capsule's git repository.
 
     Args:
         capsule: Capsule object
-        release_time: ISO 8601 timestamp to filter commits since
+        release_time: Unix timestamp or ISO 8601 timestamp to filter commits since
+        branch: Branch name, or 'HEAD' for the remote's default branch
 
     Returns:
         List of commit hashes since the release time
@@ -383,25 +401,21 @@ def get_commits_since_release(
     import tempfile
 
     git_remote_url = _get_git_remote_url(capsule.slug)
+    since = _as_git_date(release_time)
 
     # Create a temporary directory for the bare clone
     with tempfile.TemporaryDirectory() as tmpdir:
-        # Shallow bare clone (only commits, no working tree)
-        # --depth can be adjusted or removed if full history is needed
-        _run_git_command(
-            [
-                "git",
-                "clone",
-                "--bare",
-                "--single-branch",
-                "--branch",
-                branch,
-                "--shallow-since",
-                release_time,
-                git_remote_url,
-                tmpdir,
-            ]
-        )
+        # Bare clone (only commits, no working tree). Note we deliberately do
+        # not pass --shallow-since here: git aborts the clone with "error
+        # processing shallow info" when the cutoff selects no commits, which is
+        # exactly the no-commits-since-release case this function exists to
+        # detect. Filtering with git log below handles that case correctly.
+        clone_command = ["git", "clone", "--bare", "--single-branch"]
+        # 'HEAD' is not a branch name; omitting --branch follows the remote default
+        if branch and branch != "HEAD":
+            clone_command += ["--branch", branch]
+        clone_command += [git_remote_url, tmpdir]
+        _run_git_command(clone_command)
 
         # Run git log in the bare repository
         result = _run_git_command(
@@ -410,7 +424,7 @@ def get_commits_since_release(
                 "--git-dir",
                 tmpdir,
                 "log",
-                f"--since={release_time}",
+                f"--since={since}",
                 "--pretty=format:%H",
             ]
         )
@@ -431,12 +445,22 @@ def get_capsule_version_ignoring_patches(
         if there are non-patch commits since release
     """
     patch_list = patch_list.split(",") if patch_list else []
-    release = get_latest_release(capsule)
-    if release is not None:
-        time = str(release["release_time"])
-        commits = get_commits_since_release(capsule, release_time=time, branch=branch)
-        if not set(commits).difference(set(patch_list)):
-            return f"{release['major_version']}.{release['minor_version']}"
+    try:
+        release = get_latest_release(capsule)
+        if release is not None:
+            commits = get_commits_since_release(
+                capsule, release_time=release["release_time"], branch=branch
+            )
+            if not set(commits).difference(set(patch_list)):
+                return f"{release['major_version']}.{release['minor_version']}"
+    except Exception:
+        # Version lookup is best-effort metadata; callers fall back to the
+        # commit hash. Never fail an analysis run over it.
+        logging.warning(
+            f"Could not resolve release version for capsule {capsule.id}, "
+            "falling back to commit hash.",
+            exc_info=True,
+        )
     return None
 
 

--- a/src/analysis_pipeline_utils/utils_analysis_dispatch.py
+++ b/src/analysis_pipeline_utils/utils_analysis_dispatch.py
@@ -488,12 +488,16 @@ def write_input_model_list(
     -------
     None
         This function does not return any value.
-        It writes JSON files to disk for each input model.
+        It writes JSON files to disk for each input model, or a single
+        placeholder file if there were none. A capsule run in a Code Ocean
+        pipeline that produces no output at all is treated as an error, so
+        this happens even when every job has already been processed.
     """
 
     if tasks_per_job < 1:
         raise ValueError("tasks_per_job must be at least 1")
 
+    wrote_any = False
     for task_id, task_model in enumerate(input_model_list):
         if task_id == max_number_of_tasks_dispatched:
             break
@@ -503,3 +507,9 @@ def write_input_model_list(
 
         with open(job_folder / f"{uuid.uuid4()}.json", "w") as f:
             f.write(task_model.model_dump_json(indent=4))
+        wrote_any = True
+
+    if not wrote_any:
+        logger.info("No new jobs to dispatch.")
+        output_directory.mkdir(parents=True, exist_ok=True)
+        (output_directory / "no_new_jobs").touch()

--- a/src/analysis_pipeline_utils/utils_analysis_wrapper.py
+++ b/src/analysis_pipeline_utils/utils_analysis_wrapper.py
@@ -93,6 +93,12 @@ def run_analysis_jobs(
 
     Returns
     -------
+    None
+        Writes results and metadata for each job to /results. If there are
+        no input job models, writes a placeholder instead: a capsule run in
+        a Code Ocean pipeline that produces no output at all is treated as
+        an error, and every job here may legitimately have already been
+        dispatched to a different wrapper computation.
     """
     cli_cls = make_cli_model_class(analysis_input_model)
     cli_args = cli_cls()
@@ -102,6 +108,9 @@ def run_analysis_jobs(
         logger.info(f"App panel CLI parameter overrides: {cli_params}")
     input_model_paths = tuple(cli_args.input_directory.glob("job_dict/*"))
     logger.info(f"Found {len(input_model_paths)} input job models to run analysis on.")
+    if not input_model_paths:
+        os.mknod("/results/no_input_jobs")
+        return
     dry_run = bool(cli_args.dry_run)
 
     base_process = get_codeocean_process_metadata()

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -121,6 +121,41 @@ def test_construct_processing_record():
     )
 
 
+def test_update_analysis_process_leaves_base_record_reusable():
+    """Updates land on a copy so one base record can serve many jobs.
+
+    Regression test: the base record used to be updated in place, so
+    input_data accumulated and parameters carried over from job to job.
+    """
+
+    base = MockModel(
+        code=MockModel(input_data=[], parameters=MockModelWithCopy({})),
+        notes=None,
+    )
+    jobs = [
+        AnalysisDispatchModel(
+            s3_location=[f"s3://test-bucket/{name}"],
+            asset_name=[name],
+            docdb_record_id=[f"id-{name}"],
+            distributed_parameters={name: True},
+        )
+        for name in ("first", "second")
+    ]
+
+    results = [update_analysis_process(base, job) for job in jobs]
+
+    assert base.code.input_data == []
+    assert base.code.parameters.model_dump() == {}
+    assert [[asset.url for asset in result.code.input_data] for result in results] == [
+        ["s3://test-bucket/first"],
+        ["s3://test-bucket/second"],
+    ]
+    assert [result.code.parameters.model_dump() for result in results] == [
+        {"first": True},
+        {"second": True},
+    ]
+
+
 # Test _initialize_codeocean_client function
 @patch.dict(
     os.environ,

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -19,6 +19,7 @@ from analysis_pipeline_utils.metadata import (
     extract_parameters,
     get_capsule_version_ignoring_patches,
     get_commits_since_release,
+    get_release_version_for_major,
     get_data_asset_url,
     get_docdb_records,
     get_metadata_for_records,
@@ -361,8 +362,12 @@ def test_get_capsule_version_no_commits_since_release(mock_commits, mock_release
 
 @patch("analysis_pipeline_utils.metadata.get_latest_release")
 @patch("analysis_pipeline_utils.metadata.get_commits_since_release")
-def test_get_capsule_version_only_patch_commits(mock_commits, mock_release):
-    """Commits listed as patches do not invalidate the release version."""
+def test_get_capsule_version_holds_at_release(mock_commits, mock_release, caplog):
+    """Commits after a release do not change the version, but do warn.
+
+    The analysis owner decides what is a substantial new version by cutting a
+    new release (see analysis-pipeline-utils#30).
+    """
     mock_release.return_value = {
         "major_version": 2,
         "minor_version": 1,
@@ -370,13 +375,48 @@ def test_get_capsule_version_only_patch_commits(mock_commits, mock_release):
     }
     mock_commits.return_value = ["aaa", "bbb"]
 
+    assert get_capsule_version_ignoring_patches(Mock()) == "2.1"
+    assert "2 commit(s) since release 2.1" in caplog.text
+
+    # commits listed as patches are not worth warning about
+    caplog.clear()
     assert get_capsule_version_ignoring_patches(Mock(), patch_list="aaa,bbb") == "2.1"
-    assert get_capsule_version_ignoring_patches(Mock(), patch_list="aaa") is None
+    assert caplog.text == ""
 
 
 @patch("analysis_pipeline_utils.metadata.get_latest_release")
-def test_get_capsule_version_degrades_on_error(mock_release):
-    """A failed lookup returns None rather than killing the run."""
-    mock_release.side_effect = RuntimeError("git exploded")
+def test_get_capsule_version_no_release(mock_release):
+    """Without a release there is no version to use; caller falls back."""
+    mock_release.return_value = None
 
     assert get_capsule_version_ignoring_patches(Mock()) is None
+
+
+@patch("analysis_pipeline_utils.metadata.get_latest_release")
+@patch("analysis_pipeline_utils.metadata.get_commits_since_release")
+def test_get_capsule_version_survives_commit_lookup_failure(mock_commits, mock_release):
+    """A failed commit listing must not change the recorded version."""
+    mock_release.return_value = {
+        "major_version": 2,
+        "minor_version": 0,
+        "release_time": 1768017516,
+    }
+    mock_commits.side_effect = RuntimeError("git exploded")
+
+    assert get_capsule_version_ignoring_patches(Mock()) == "2.0"
+
+
+@patch("analysis_pipeline_utils.metadata.get_capsule_releases")
+def test_get_release_version_for_major(mock_releases):
+    """A pinned component's int major version expands to '<major>.<minor>'."""
+    mock_releases.return_value = [
+        {"major_version": 1, "minor_version": 0, "release_time": 1},
+        {"major_version": 2, "minor_version": 0, "release_time": 2},
+        {"major_version": 2, "minor_version": 3, "release_time": 3},
+    ]
+
+    # latest minor wins within a major
+    assert get_release_version_for_major(Mock(), 2) == "2.3"
+    assert get_release_version_for_major(Mock(), 1) == "1.0"
+    # unknown major degrades rather than failing
+    assert get_release_version_for_major(Mock(), 9) == "9"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -42,6 +42,7 @@ def mock_computation():
         run_time=3600,
         name="test_capsule",
         state=ComputationState.Running,
+        owner="test_user",
     )
     return computation
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,6 +1,7 @@
 """Tests functions for processing metadata."""
 
 import os
+from datetime import datetime
 from types import SimpleNamespace as MockModel
 from unittest.mock import Mock, patch
 
@@ -16,6 +17,8 @@ from analysis_pipeline_utils.metadata import (
     update_analysis_process,
     docdb_record_exists,
     extract_parameters,
+    get_capsule_version_ignoring_patches,
+    get_commits_since_release,
     get_data_asset_url,
     get_docdb_records,
     get_metadata_for_records,
@@ -269,3 +272,76 @@ def test_get_metadata_for_records_none_found(mock_get_record, mock_client_cls):
 
     assert result == []
     assert mock_get_record.call_count == 2
+
+
+# Test release version lookup (see issue #48)
+@patch("analysis_pipeline_utils.metadata._get_git_remote_url")
+@patch("analysis_pipeline_utils.metadata._run_git_command")
+def test_get_commits_since_release_converts_timestamp(mock_git, mock_url):
+    """Unix timestamps from the Code Ocean API are converted for git."""
+    mock_url.return_value = "https://example.com/capsule-1.git"
+    mock_git.return_value = "abc123\ndef456"
+
+    result = get_commits_since_release(Mock(slug="1"), release_time=1768017516)
+
+    assert result == ["abc123", "def456"]
+    log_command = mock_git.call_args_list[-1].args[0]
+    since = next(a for a in log_command if a.startswith("--since="))
+    assert since == f"--since={datetime.fromtimestamp(1768017516).isoformat()}"
+
+
+@patch("analysis_pipeline_utils.metadata._get_git_remote_url")
+@patch("analysis_pipeline_utils.metadata._run_git_command")
+def test_get_commits_since_release_clone_args(mock_git, mock_url):
+    """The clone omits --branch for HEAD and never passes --shallow-since."""
+    mock_url.return_value = "https://example.com/capsule-1.git"
+    mock_git.return_value = ""
+
+    get_commits_since_release(Mock(slug="1"), release_time=1768017516)
+    clone_command = mock_git.call_args_list[0].args[0]
+    # 'HEAD' is not a branch name and would fail with "Remote branch not found"
+    assert "--branch" not in clone_command
+    # --shallow-since aborts the clone when no commits match the cutoff
+    assert "--shallow-since" not in clone_command
+
+    mock_git.reset_mock()
+    get_commits_since_release(Mock(slug="1"), release_time=1768017516, branch="main")
+    clone_command = mock_git.call_args_list[0].args[0]
+    assert clone_command[clone_command.index("--branch") + 1] == "main"
+
+
+@patch("analysis_pipeline_utils.metadata.get_latest_release")
+@patch("analysis_pipeline_utils.metadata.get_commits_since_release")
+def test_get_capsule_version_no_commits_since_release(mock_commits, mock_release):
+    """No commits since release means the release version is used."""
+    mock_release.return_value = {
+        "major_version": 2,
+        "minor_version": 0,
+        "release_time": 1768017516,
+    }
+    mock_commits.return_value = []
+
+    assert get_capsule_version_ignoring_patches(Mock()) == "2.0"
+
+
+@patch("analysis_pipeline_utils.metadata.get_latest_release")
+@patch("analysis_pipeline_utils.metadata.get_commits_since_release")
+def test_get_capsule_version_only_patch_commits(mock_commits, mock_release):
+    """Commits listed as patches do not invalidate the release version."""
+    mock_release.return_value = {
+        "major_version": 2,
+        "minor_version": 1,
+        "release_time": 1768017516,
+    }
+    mock_commits.return_value = ["aaa", "bbb"]
+
+    assert get_capsule_version_ignoring_patches(Mock(), patch_list="aaa,bbb") == "2.1"
+    assert get_capsule_version_ignoring_patches(Mock(), patch_list="aaa") is None
+
+
+@patch("analysis_pipeline_utils.metadata.get_latest_release")
+def test_get_capsule_version_degrades_on_error(mock_release):
+    """A failed lookup returns None rather than killing the run."""
+    mock_release.side_effect = RuntimeError("git exploded")
+
+    assert get_capsule_version_ignoring_patches(Mock()) is None

--- a/tests/test_result_files.py
+++ b/tests/test_result_files.py
@@ -23,6 +23,8 @@ def mock_process():
     """Create a mock DataProcess object for testing."""
     process = ps.DataProcess(
         experimenters=["Test User"],
+        # aind-data-schema requires name or notes for an Analysis process
+        name="Test analysis",
         process_type=ps.ProcessName.ANALYSIS,
         stage=ps.ProcessStage.ANALYSIS,
         start_date_time="2023-10-01T00:00:00Z",

--- a/tests/test_utils_analysis_dispatch.py
+++ b/tests/test_utils_analysis_dispatch.py
@@ -505,6 +505,28 @@ def test_write_input_model_list_invalid_group_size(tmp_path):
         write_input_model_list(iter([model]), tmp_path, tasks_per_job=0)
 
 
+def test_write_input_model_list_no_jobs_writes_placeholder(tmp_path):
+    """A capsule that produces no output at all fails a CO pipeline run,
+    so an empty input list must still leave something in output_directory.
+    """
+
+    write_input_model_list(iter([]), tmp_path)
+
+    assert list(tmp_path.iterdir()) == [tmp_path / "no_new_jobs"]
+
+
+def test_write_input_model_list_zero_max_dispatched_writes_placeholder(tmp_path):
+    """max_number_of_tasks_dispatched=0 also dispatches nothing."""
+
+    model = AnalysisDispatchModel(
+        s3_location=["bucket/a"], asset_name=["a"], docdb_record_id=["doc"]
+    )
+
+    write_input_model_list(iter([model]), tmp_path, max_number_of_tasks_dispatched=0)
+
+    assert list(tmp_path.iterdir()) == [tmp_path / "no_new_jobs"]
+
+
 @patch("analysis_pipeline_utils.utils_analysis_dispatch.docdb_record_exists")
 @patch("analysis_pipeline_utils.utils_analysis_dispatch.update_analysis_process")
 @patch("analysis_pipeline_utils.utils_analysis_dispatch.get_codeocean_process_metadata")

--- a/tests/test_utils_analysis_dispatch.py
+++ b/tests/test_utils_analysis_dispatch.py
@@ -569,3 +569,62 @@ def test_check_task_parameters_no_filter(mock_get_process, mock_construct, mock_
     assert results[0].analysis_code.name == "first"
     assert results[1].analysis_code.name == "second"
     assert mock_exists.call_count == 0
+
+
+class MockParameters:
+    """Minimal stand-in for a pydantic parameters model."""
+
+    def __init__(self, data: dict[str, object] | None = None):
+        """Initialize fields"""
+        self._data = dict(data or {})
+
+    def model_copy(self, update: dict[str, object] | None = None):
+        """Returns a copy with updated data"""
+        return MockParameters({**self._data, **(update or {})})
+
+    def model_dump(self):
+        """Dumps model to dict"""
+        return dict(self._data)
+
+
+@patch("analysis_pipeline_utils.utils_analysis_dispatch.docdb_record_exists")
+@patch("analysis_pipeline_utils.utils_analysis_dispatch.get_codeocean_process_metadata")
+def test_check_task_parameters_builds_independent_records(
+    mock_get_process, mock_exists
+):
+    """Every job gets its own record, built from a single shared base.
+
+    Exercises the real update_analysis_process rather than a mock: the base
+    record used to be updated in place, so input_data accumulated and
+    parameters carried over. That changes the record hash, and only the first
+    job in a batch could be recognized as already processed.
+    """
+
+    mock_get_process.return_value = MockModel(
+        code=MockModel(input_data=[], parameters=MockParameters()),
+        notes=None,
+    )
+    mock_exists.return_value = False
+
+    inputs = [
+        AnalysisDispatchModel(
+            s3_location=[f"bucket/{name}"],
+            asset_name=[name],
+            docdb_record_id=[f"doc-{name}"],
+            distributed_parameters={name: True},
+        )
+        for name in ("a", "b", "c")
+    ]
+
+    results = list(check_task_parameters(iter(inputs), fixed_analysis_params={"x": 1}))
+
+    # the Code Ocean lookup stays hoisted out of the loop
+    mock_get_process.assert_called_once()
+    assert [
+        [asset.url for asset in result.analysis_code.input_data] for result in results
+    ] == [["bucket/a"], ["bucket/b"], ["bucket/c"]]
+    assert [result.analysis_code.parameters.model_dump() for result in results] == [
+        {"x": 1, "a": True},
+        {"x": 1, "b": True},
+        {"x": 1, "c": True},
+    ]

--- a/tests/test_utils_analysis_wrapper.py
+++ b/tests/test_utils_analysis_wrapper.py
@@ -197,3 +197,37 @@ def test_run_analysis_jobs_skips_processed_job(tmp_path):
     mock_write.assert_not_called()
     marker_name = f"/results/skip_{job_path.stem}"
     mock_mknod.assert_called_once_with(marker_name)
+
+
+def test_run_analysis_jobs_no_input_writes_placeholder(tmp_path):
+    """No input job models still leaves a marker in /results.
+
+    A capsule run in a Code Ocean pipeline that produces no output at all is
+    treated as an error, and this wrapper may legitimately have received no
+    jobs if a dispatcher-side skip routed them elsewhere.
+    """
+
+    fake_cli_args = MockModel(
+        dry_run=1,
+        input_directory=tmp_path,
+        model_dump=lambda exclude_unset=True: {},
+    )
+
+    with (
+        patch(
+            "analysis_pipeline_utils.utils_analysis_wrapper.make_cli_model_class",
+            return_value=MagicMock(return_value=fake_cli_args),
+        ),
+        patch(
+            "analysis_pipeline_utils.utils_analysis_wrapper.get_codeocean_process_metadata"  # noqa: E501
+        ) as mock_get_process,
+        patch("analysis_pipeline_utils.utils_analysis_wrapper.os.mknod") as mock_mknod,
+        patch(
+            "analysis_pipeline_utils.utils_analysis_wrapper.write_results_and_metadata"
+        ) as mock_write,
+    ):
+        run_analysis_jobs(ExampleInput, ExampleOutput, MagicMock())
+
+    mock_get_process.assert_not_called()
+    mock_write.assert_not_called()
+    mock_mknod.assert_called_once_with("/results/no_input_jobs")


### PR DESCRIPTION
Several related fixes to how analysis version and job identity are recorded, surfaced together while migrating the dynamic foraging model pipeline to the latest v2+ framework. Bundled since they touch the same code path and are all urgent weekend fixes for the upcoming data club.

Also fixes AllenNeuralDynamics/aind-analysis-wrapper-template#18 (results already computed showing up as pipeline failures) — that was closed citing #745, but #745 doesn't actually address it; #4 and #5 below do.

| | commit |
|---|---|
| Release-version lookup crashed against the Code Ocean git server | `72f92e1` — closes #48 |
| One shared process record was mutated across all jobs in a batch | `51d5d6b` — refs AllenNeuralDynamics/aind-physio-arch#745 |
| Version didn't hold at the latest release | `bcf94e8` — refs #30 |
| Test fixtures broken by newer codeocean / aind-data-schema | `84e36d2` |
| Dispatcher produced no output when everything was already processed | `acab6f6` — fixes AllenNeuralDynamics/aind-analysis-wrapper-template#18 |
| Same, on the wrapper side, when it receives no input job models | `b7c29dc` — fixes AllenNeuralDynamics/aind-analysis-wrapper-template#18 |

---

## 1. Release-version lookup (#48)

`get_commits_since_release()` couldn't run at all:

- `git clone --shallow-since` aborts with `fatal: error processing shallow info: 4` when the cutoff selects no commits — exactly the no-commits-since-release case the function exists to detect. Dropped the flag; `git log --since` does the filtering.
- `'HEAD'` was passed to `git clone --branch`, which isn't a branch name. Omitted so the clone follows the remote default. This is the default whenever `CO_CAPSULE_BRANCH` is unset.
- `release_time` arrives from the API as a unix timestamp, so it's now converted rather than interpolated as-is.

Present in 0.2.1 through 0.2.5 (`v0.2.5` and `main` are byte-identical here).

## 2. Fixed a bug in hashing "code" iteratively across jobs (aind-physio-arch#745)

`update_analysis_process()` applied its updates to the record it was handed and returned that same object. Both callers fetch one base record before their loop, so state accumulated across jobs:

```
model 1: input_data=['s3://bucket/asset1']
model 2: input_data=['s3://bucket/asset1', 's3://bucket/asset2']
model 3: input_data=['s3://bucket/asset1', 's3://bucket/asset2', 's3://bucket/asset3']
```

Parameters carried over the same way. Since `processing_prefix()` hashes the whole `code` record, the hash checked at dispatch drifted from the one the wrapper later wrote, so only the first job in a batch could be recognized as already processed.

Copying inside `update_analysis_process()` fixes both loops at once and keeps the single Code Ocean lookup per capsule that hoisting the base record out of the loop was there to buy.

## 3. Version holds at the latest release (#30)

This implements the three paths agreed in #30, with the first two corrected:

| Situation | Agreed in #30 | Before | After |
|---|---|---|---|
| Pipeline component **pinned to a release** | use the CO release | `ValidationError` — see below | `"2.0"` |
| Capsule **has releases, commits since** | latest release + prominent warning, commit recorded outside `code` | commit hash (or the #48 crash) | `"2.0"` + warning |
| Capsule with **no releases** | commit hash | commit hash | commit hash — unchanged |

**Path 1** never worked. `PipelineProcess.version` is `Optional[int]`, holding the major version only, and the old `if not version:` treated `2` as truthy and passed it straight to `ps.Code`, whose field is `Optional[str]`:

```
version: Input should be a valid string [type=string_type, input_value=2, input_type=int]
```

It's now expanded to `"<major>.<minor>"` against the release capsule. The formatting matters: without it, a pinned run of release 2.0 records `"2"` while an unpinned run of the same release records `"2.0"` — two hashes for identical code.

**Path 2** returned the release version only when there were *no* commits since it, unless each was listed by SHA in `PATCH_COMMITS`. Any capsule under active development therefore fell back to a commit hash, which is the behavior #30 was filed to remove. `patch_list` now only decides whether to warn. Real example from a wrapper capsule:

```
[WARNING] Capsule han_df_mle_aind-analysis-wrapper-v2 has 45 commit(s) since
release 2.0, which is still being recorded as the analysis version. Cut a new
release if those commits substantially change results, otherwise jobs already
processed under this version will not be re-run.

code.version : '2.0'      (was 'bf0fe5b8…')
notes        : 'Git commit hash: 9318611f…'
```

The commit still goes to `process.notes`, outside `code`, so it doesn't affect job-skipping.

One deliberate narrowing: the version no longer depends on the git clone succeeding — only the warning does. A transient git failure used to drop the version to a commit hash, silently changing the identity of every job. This narrows the catch-all added in `72f92e1`, which is no longer needed for that crash since the clone is off the version path entirely.

---

## Behavior change to be aware of

After this, a capsule that has releases stops starting a new analysis version on every commit. That is the intent of #30, but it is a change in default behavior for everyone: jobs already processed under a release will no longer re-run after unreleased commits, until a new release is cut. The warning is there to make that visible.

Existing records are invalidated once, since `code.version` changes form.

## What this does *not* address

`processing_prefix()` hashes the entire `code` record, so job identity still includes more than the analysis. Found while debugging a dispatch that skipped 0 of 48 already-completed jobs:

- **`code.name`** — renaming a capsule (`…-wrapper` → `…-wrapper-v2`) invalidates every prior record.
- **aind-data-schema serialization** — 2.4.0 removed `Code.commit_hash` and `DataAsset.name`. Records written before that can't have their hash regenerated at all; `ps.Code.model_validate` on a stored record now raises `extra_forbidden`. Measured on 48 real records: 48/48 reproduce their own hash from stored JSON, 0/48 once those two fields are dropped.
- **`parameters["dry run"]`** — the app-panel toggle sits inside the hashed identity. `update_analysis_process` pops `dry_run`, but Code Ocean reports the display name `"dry run"` with a space, so the pop misses it.

#30 reasoned about `code.version` alone, which is why fixing it doesn't fully settle this. There's a TODO already on the line above the hash — `# TODO: hash on input data + parameters from process.code` — that would cover the rest. Narrowing the scope invalidates existing records, so it seemed better raised than quietly changed. Detail in aind-physio-arch#745.

## 4. Placeholder when nothing is dispatched (AllenNeuralDynamics/aind-analysis-wrapper-template#18)

`write_input_model_list()` wrote nothing to `output_directory` when every job was filtered out by `check_task_parameters()`. A Code Ocean pipeline capsule that produces no output at all is treated as a failed step — so a dispatch where everything had already been processed, which is the whole point of #745, would fail the pipeline rather than just skip the downstream work. This is exactly aind-analysis-wrapper-template#18: results already computed show up as a pipeline failure, making them indistinguishable from a real one. Now writes an empty `no_new_jobs` marker in that case.

#18 was closed citing #745 as the fix, but #745 only addresses the accumulation bug in commit `51d5d6b` above — it doesn't touch this. This commit does.

## 5. Same placeholder, on the wrapper side (also aind-analysis-wrapper-template#18)

`run_analysis_jobs()` has the identical gap: when `glob("job_dict/*")` finds no job models, the `for` loop never runs, so nothing in its body — the `skip_<job>` marker or `write_results_and_metadata()`, both of which always write something per job — ever executes, and `/results` ends up empty. Same failure mode as #18, on the wrapper side rather than the dispatcher.

(`write_results_and_metadata()` itself is not the right place for this guard: it's called once per completed job and always writes `/results/metadata.nd.json` regardless of `dry_run`, so it's never silently empty on its own. The gap is one level up, at zero iterations rather than zero output from an iteration — same shape as #4 above.)

Receiving zero job models is a legitimate outcome for a wrapper too, not just dispatcher-side — e.g. splitting work across several wrapper computations, one of which ends up empty.

## 6. Test fixtures vs. current dependencies

CI installs the newest `aind-data-schema` and `codeocean` (`pyproject.toml` allows `>=2.4.0` and leaves `codeocean` unpinned), and 6 tests errored at fixture setup — unrelated to the rest of this PR, reproduces on `main`:

- `Computation.__init__() missing … 'owner'` — codeocean 0.15.0 made it required
- `If 'process_type' is Other or Analysis, either 'name' or 'notes' must specify process details` (×5) — aind-data-schema 2.8.1 added this validator

The `owner` fix duplicates #41, which predates the `DataProcess` validator and doesn't cover the other 5. Expect a trivial conflict if #41 merges first.

## Verification

`57 passed` against CI's dependency set (codeocean 0.15.0, aind-data-schema 2.8.1, reproduced locally in a clean venv), flake8 clean, interrogate 100%. `black` flags the same four files as `main` does, none of them touched here.

New regression tests fail without their fix and pass with it:

- `test_update_analysis_process_leaves_base_record_reusable` — the base record stays reusable
- `test_check_task_parameters_builds_independent_records` — drives the real dispatcher loop over three jobs with `update_analysis_process` unmocked, and asserts the Code Ocean lookup stays hoisted
- `test_get_capsule_version_holds_at_release` — version holds, warning fires, `patch_list` suppresses it
- `test_get_capsule_version_survives_commit_lookup_failure` — a failed commit listing doesn't change the version
- `test_get_release_version_for_major` — int major expands to `<major>.<minor>`, latest minor wins, unknown major degrades
- `test_write_input_model_list_no_jobs_writes_placeholder`, `test_write_input_model_list_zero_max_dispatched_writes_placeholder` — dispatcher placeholder written only when nothing is dispatched
- `test_run_analysis_jobs_no_input_writes_placeholder` — wrapper placeholder written only when there are no input job models, and the Code Ocean lookup is skipped rather than made needlessly

Also exercised end to end against a live capsule and DocDB: version resolution, the warning, and a full wrapper dry run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
