### PR TITLE
fix: expand a pinned component's release version to '<major>.<minor>' (#51)

### DIFF
--- a/src/analysis_pipeline_utils/metadata.py
+++ b/src/analysis_pipeline_utils/metadata.py
@@ -239,7 +239,13 @@ def get_codeocean_process_metadata(
 
     capsule = client.capsules.get_capsule(capsule_id)
     process.name = capsule.name
-    if not version:
+    if version:
+        # Code Ocean reports the release of a pinned pipeline component as an
+        # int holding the major version only, which ps.Code rejects. Expand it
+        # to '<major>.<minor>' so it matches the version recorded when the same
+        # release runs unpinned, and the two agree on the hash.
+        version = get_release_version_for_major(capsule, version)
+    else:
         branch = os.getenv("CO_CAPSULE_BRANCH", "HEAD")
         patch_list = os.getenv("PATCH_COMMITS")
         version = get_capsule_version_ignoring_patches(
@@ -352,6 +358,59 @@ def get_capsule_commit_hash(capsule: Capsule, branch="HEAD") -> str:
     return git_commit_hash.split()[0]  # Return the commit hash part
 
 
+def get_capsule_releases(capsule: Capsule) -> List[dict]:
+    """Get all releases for a specific capsule, oldest first.
+
+    Args:
+        capsule: Capsule object
+
+    Returns:
+        List of release dicts, empty if the capsule has no release capsule
+    """
+    if not capsule.release_capsule:
+        return []
+    client = _initialize_codeocean_client()
+    release_capsule = client.capsules.get_capsule(capsule.release_capsule)
+    return release_capsule.versions or []
+
+
+def format_release_version(release: dict) -> str:
+    """Format a Code Ocean release as a '<major>.<minor>' version string.
+
+    Args:
+        release: Release dict from the Code Ocean API
+
+    Returns:
+        str: Version string, e.g. '2.0'
+    """
+    return f"{release['major_version']}.{release['minor_version']}"
+
+
+def get_release_version_for_major(capsule: Capsule, major_version: int) -> str:
+    """Resolve a major version number to a full '<major>.<minor>' string.
+
+    Code Ocean reports the release of a pinned pipeline component as an int
+    holding only the major version. Look up the matching release so the
+    recorded version has the same form as for an unpinned run.
+
+    Args:
+        capsule: Capsule object
+        major_version: Major version reported by the pipeline process
+
+    Returns:
+        str: Version string, falling back to the major version alone
+        if no matching release is found
+    """
+    matching = [
+        release
+        for release in get_capsule_releases(capsule)
+        if release["major_version"] == major_version
+    ]
+    if not matching:
+        return str(major_version)
+    return format_release_version(matching[-1])
+
+
 def get_latest_release(capsule: Capsule) -> Optional[dict]:
     """Get the latest release information for a specific capsule.
     Args:
@@ -359,11 +418,9 @@ def get_latest_release(capsule: Capsule) -> Optional[dict]:
     Returns:
         dict: Latest release information, or None if no releases found
     """
-    if not capsule.release_capsule:
+    versions = get_capsule_releases(capsule)
+    if not versions:
         return None
-    client = _initialize_codeocean_client()
-    release_capsule = client.capsules.get_capsule(capsule.release_capsule)
-    versions = release_capsule.versions
     latest = versions[-1]
     return latest
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -19,6 +19,7 @@ from analysis_pipeline_utils.metadata import (
     get_data_asset_url,
     get_docdb_records,
     get_metadata_for_records,
+    get_release_version_for_major,
 )
 
 
@@ -269,3 +270,19 @@ def test_get_metadata_for_records_none_found(mock_get_record, mock_client_cls):
 
     assert result == []
     assert mock_get_record.call_count == 2
+
+
+@patch("analysis_pipeline_utils.metadata.get_capsule_releases")
+def test_get_release_version_for_major(mock_releases):
+    """A pinned component's int major version expands to '<major>.<minor>'."""
+    mock_releases.return_value = [
+        {"major_version": 1, "minor_version": 0, "release_time": 1},
+        {"major_version": 2, "minor_version": 0, "release_time": 2},
+        {"major_version": 2, "minor_version": 3, "release_time": 3},
+    ]
+
+    # latest minor wins within a major
+    assert get_release_version_for_major(Mock(), 2) == "2.3"
+    assert get_release_version_for_major(Mock(), 1) == "1.0"
+    # unknown major degrades rather than failing
+    assert get_release_version_for_major(Mock(), 9) == "9"


### PR DESCRIPTION
Closes #51. Split out of #49 per [tmchartrand's review](https://github.com/AllenNeuralDynamics/analysis-pipeline-utils/pull/49#issuecomment-5084703132).

This is the part of `bcf94e8` you identified as the #51 fix, **without** the #30 behavior change. `get_capsule_version_ignoring_patches()` is untouched here — it still returns the release version only when there are no non-patch commits since it. The question of whether the version should hold at the latest release stays open for discussion on #30.

### The bug

Code Ocean reports the release of a pinned pipeline component through `PipelineProcess.version` as `Optional[int]`, holding the major version only. `ps.Code.version` is `Optional[str]`, and the old `if not version:` treated `2` as truthy and passed it straight through:

```
version: Input should be a valid string [type=string_type, input_value=2, input_type=int]
```

So running a released capsule — the case that was supposed to already work — raised instead.

### The fix

The major version is resolved against the release capsule and expanded to `'<major>.<minor>'`. The formatting matters beyond the type error: without it a pinned run of release 2.0 records `"2"` while an unpinned run of the same release records `"2.0"`, giving two different hashes for identical code.

Adds `get_capsule_releases()` and `format_release_version()` as shared helpers; `get_latest_release()` now goes through the former instead of duplicating the release-capsule lookup.

### Testing
One new test covering major→'<major>.<minor>' resolution, latest-minor-wins, and the unknown-major fallback. Full suite passes (46 passed) once #41's fixture updates are in; the 6 remaining errors here also reproduce on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)