### PR TITLE
feat: hold the analysis version at the latest capsule release (#30)

### DIFF
--- a/src/analysis_pipeline_utils/metadata.py
+++ b/src/analysis_pipeline_utils/metadata.py
@@ -239,15 +239,17 @@ def get_codeocean_process_metadata(
 
     capsule = client.capsules.get_capsule(capsule_id)
     process.name = capsule.name
+    branch = os.getenv("CO_CAPSULE_BRANCH", "HEAD")
     if not version:
-        branch = os.getenv("CO_CAPSULE_BRANCH", "HEAD")
         patch_list = os.getenv("PATCH_COMMITS")
         version = get_capsule_version_ignoring_patches(
             capsule, patch_list=patch_list, branch=branch
         )
-        hash = get_capsule_commit_hash(capsule, branch)
-        version = version or hash
-        process.notes = f"Git commit hash: {hash}"
+    # Recorded outside code so it never affects job-skipping, but stays
+    # available for tracing which commit actually ran.
+    hash = get_capsule_commit_hash(capsule, branch)
+    version = version or hash
+    process.notes = f"Git commit hash: {hash}"
 
     if computation.data_assets:
         input_data = [
@@ -421,23 +423,55 @@ def get_commits_since_release(
 def get_capsule_version_ignoring_patches(
     capsule: Capsule, branch="HEAD", patch_list: Optional[str] = None
 ) -> Optional[str]:
-    """Get the capsule version from the latest release, ignoring patch commits.
+    """Get the capsule version from the latest release.
+
+    The latest release is used whenever the capsule has one, so that commits
+    made after it do not change the recorded version. This lets the analysis
+    owner decide what counts as a substantial new version of the analysis by
+    cutting a new release, rather than having every commit start a new one.
+
+    Commits since the release do not change the version, but are reported as
+    a warning unless they are listed in patch_list.
+
     Args:
         capsule: Capsule object
         branch: Branch name or 'HEAD' to specify which version to retrieve
-        patch_list: Optional comma-separated list of patch commit hashes to ignore
+        patch_list: Optional comma-separated list of patch commit hashes to
+            ignore when deciding whether to warn
+
     Returns:
         str: Version of the capsule based on the latest release, or None
-        if there are non-patch commits since release
+        if the capsule has no releases
     """
-    patch_list = patch_list.split(",") if patch_list else []
     release = get_latest_release(capsule)
-    if release is not None:
+    if release is None:
+        return None
+    version = f"{release['major_version']}.{release['minor_version']}"
+
+    patch_list = patch_list.split(",") if patch_list else []
+    try:
         time = str(release["release_time"])
         commits = get_commits_since_release(capsule, release_time=time, branch=branch)
-        if not set(commits).difference(set(patch_list)):
-            return f"{release['major_version']}.{release['minor_version']}"
-    return None
+    except Exception:
+        # Only the warning below depends on this; the version does not, so a
+        # failure here must never change the recorded version.
+        logging.warning(
+            f"Could not list commits since release {version} "
+            f"for capsule {capsule.name}.",
+            exc_info=True,
+        )
+        return version
+
+    unpatched = set(commits).difference(set(patch_list))
+    if unpatched:
+        logging.warning(
+            f"Capsule {capsule.name} has {len(unpatched)} commit(s) since "
+            f"release {version}, which is still being recorded as the "
+            "analysis version. Cut a new release if those commits "
+            "substantially change results, otherwise jobs already processed "
+            "under this version will not be re-run."
+        )
+    return version
 
 
 def get_capsule_url(capsule: Capsule) -> str:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -19,6 +19,7 @@ from analysis_pipeline_utils.metadata import (
     get_data_asset_url,
     get_docdb_records,
     get_metadata_for_records,
+    get_capsule_version_ignoring_patches,
 )
 
 
@@ -269,3 +270,49 @@ def test_get_metadata_for_records_none_found(mock_get_record, mock_client_cls):
 
     assert result == []
     assert mock_get_record.call_count == 2
+
+
+@patch("analysis_pipeline_utils.metadata.get_latest_release")
+@patch("analysis_pipeline_utils.metadata.get_commits_since_release")
+def test_get_capsule_version_holds_at_release(mock_commits, mock_release, caplog):
+    """Commits after a release do not change the version, but do warn.
+
+    The analysis owner decides what is a substantial new version by cutting a
+    new release (see analysis-pipeline-utils#30).
+    """
+    mock_release.return_value = {
+        "major_version": 2,
+        "minor_version": 1,
+        "release_time": 1768017516,
+    }
+    mock_commits.return_value = ["aaa", "bbb"]
+
+    assert get_capsule_version_ignoring_patches(Mock()) == "2.1"
+    assert "2 commit(s) since release 2.1" in caplog.text
+
+    # commits listed as patches are not worth warning about
+    caplog.clear()
+    assert get_capsule_version_ignoring_patches(Mock(), patch_list="aaa,bbb") == "2.1"
+    assert caplog.text == ""
+
+
+@patch("analysis_pipeline_utils.metadata.get_latest_release")
+def test_get_capsule_version_no_release(mock_release):
+    """Without a release there is no version to use; caller falls back."""
+    mock_release.return_value = None
+
+    assert get_capsule_version_ignoring_patches(Mock()) is None
+
+
+@patch("analysis_pipeline_utils.metadata.get_latest_release")
+@patch("analysis_pipeline_utils.metadata.get_commits_since_release")
+def test_get_capsule_version_survives_commit_lookup_failure(mock_commits, mock_release):
+    """A failed commit listing must not change the recorded version."""
+    mock_release.return_value = {
+        "major_version": 2,
+        "minor_version": 0,
+        "release_time": 1768017516,
+    }
+    mock_commits.side_effect = RuntimeError("git exploded")
+
+    assert get_capsule_version_ignoring_patches(Mock()) == "2.0"


### PR DESCRIPTION
Implements the middle path from #30. **Not for merging until the design question in #57 is settled** — putting it up so there's something concrete to react to, and happy to close it if we stay with the current rule.

### What changes

`get_capsule_version_ignoring_patches()` returns the latest release version whenever the capsule has one, rather than only when every commit since that release is enumerated in `PATCH_COMMITS`. `patch_list` now decides only whether to warn.

| Situation | Before | After |
|---|---|---|
| Capsule has releases, no commits since | `2.0` | `2.0` |
| Capsule has releases, commits since, all in `PATCH_COMMITS` | `2.0` | `2.0` |
| Capsule has releases, commits since, not all listed | commit hash | `2.0` + warning |
| Capsule has no releases | commit hash | commit hash |

Only the third row moves. Drift is reported rather than silently accepted:

```
Capsule han_df_mle_aind-analysis-wrapper-v2 has 45 commit(s) since release 2.0,
which is still being recorded as the analysis version. Cut a new release if
those commits substantially change results, otherwise jobs already processed
under this version will not be re-run.
```

Two smaller things come with it:

- The commit hash moves out of the `if not version:` branch, so it lands on `process.notes` for every path — including a pinned release run, which currently records no commit at all. `notes` is outside `code`, so provenance improves without affecting job-skipping.
- The version no longer depends on the git clone succeeding; only the warning does. A transient git failure previously dropped the version to a commit hash, silently changing the identity of every job.

### This changes default behavior

Worth being explicit: jobs already processed under a release stop re-running after unreleased commits until a new release is cut. That is the intent, and it's the tradeoff argued in #57 — the failure mode is 'nothing dispatched, cut a release', rather than 'tens of thousands of duplicate jobs to clean out of S3 and DocDB'.

It also doesn't deliver stable job identity on its own, since `processing_prefix()` hashes the whole `code` record and `code.name` plus the aind-data-schema serialization move it too. Detail in AllenNeuralDynamics/aind-physio-arch#745.

### Relationship to the other PRs

Branched from `main` and self-contained, so it can be reviewed independently. It does touch the same function as #53, so expect a small conflict there — I'll rebase once #53 lands. #55 adds a `format_release_version()` helper that this could use afterward; left inline here to avoid a dependency.

### Testing
3 new tests: version holds across unlisted commits and warns, patch-listed commits suppress the warning, no-release returns `None`, and a failed commit listing leaves the version intact. Suite passes (48 passed) with #41's fixture updates applied; the 6 errors otherwise present also reproduce on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)