### PR TITLE
ci: pip install command to use --group flag

### DIFF
--- a/.github/workflows/tag_and_publish.yml
+++ b/.github/workflows/tag_and_publish.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: '3.10'
     - name: Install dependencies
       run: | 
-        python -m pip install -e .[dev] --no-cache-dir
+        python -m pip install -e . --group dev --no-cache-dir
     - name: Get Python version and Update README.md
       run: |
         python_version=$(grep "requires-python" pyproject.toml | grep -o ">=[^\"]*")


### PR DESCRIPTION
I previously moved the dev dependencies to a group instead of extras, but didn't update the badges workflow